### PR TITLE
Update the podspec to allow CocoaLumberjack 2.0.1

### DIFF
--- a/PubNub.podspec
+++ b/PubNub.podspec
@@ -41,7 +41,10 @@ Pod::Spec.new do |s|
   ]
 
   s.library   = "z"
-  s.dependency "CocoaLumberjack", "2.0.0"
+
+  ## 2015-09-02 DriveKit MOD: Switching to CocoaLumberjack 2.0.1 because 2.0.0 has bugs. The
+  ## publicly released PubNub iOS CocoaPod requires 2.0.0.
+  s.dependency "CocoaLumberjack", "~> 2.0.1"
 
 
 s.license = %{ :type => "MIT", :text => <<-LICENSE'


### PR DESCRIPTION
We have found CocoaLumberjack 2.0.0 to be problematic and have had to add workarounds in our code to fix them.
